### PR TITLE
Feature confirm appointment #13

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,7 +29,7 @@ function App(): JSX.Element {
             <Route exact path="/signup" component={Signup} />
             <Route exact path="/AuthSetup" component={AuthSetUp} />
             <Route exact path="/dashboard" component={Dashboard} />
-            <Route exact path="/scheduler/:username/:duration" component={Scheduler} />\
+            <Route exact path="/scheduler/:username/:duration" component={Scheduler} />
             <Route exact path="/completion" component={Completion} />
             <Route exact path="/profile_settings" component={ProfileSettings} />
             <Route exact path="/confirm" component={Confirm} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
+import Completion from './pages/Scheduler/Completion/Completion';
+import Scheduler from './pages/Scheduler/Scheduler';
 
 import ProfileSettings from './pages/Onboarding/ProfileSettings/ProfileSettings';
 import Confirm from './pages/Onboarding/Confirm/Confirm';
@@ -27,6 +29,8 @@ function App(): JSX.Element {
             <Route exact path="/signup" component={Signup} />
             <Route exact path="/AuthSetup" component={AuthSetUp} />
             <Route exact path="/dashboard" component={Dashboard} />
+            <Route exact path="/scheduler/:username/:duration" component={Scheduler} />\
+            <Route exact path="/completion" component={Completion} />
             <Route exact path="/profile_settings" component={ProfileSettings} />
             <Route exact path="/confirm" component={Confirm} />
             <Route exact path="/availability" component={Availability} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './context/useAuthContext';
 import ProfileSettings from './pages/Onboarding/ProfileSettings/ProfileSettings';
 import Confirm from './pages/Onboarding/Confirm/Confirm';
 import Availability from './pages/Onboarding/Availability/Availability';
+import Completion from './pages/Scheduler/Completion/Completion';
 
 import './App.css';
 import Scheduler from './pages/Scheduler/Scheduler';
@@ -18,17 +19,18 @@ function App(): JSX.Element {
         {/* <SnackBarProvider>
           <AuthProvider> */}
         <Switch>
-          <Route exact path="/login" component={Login} />
-          <Route exact path="/signup" component={Signup} />
+          {/* <Route exact path="/login" component={Login} />
+          <Route exact path="/signup" component={Signup} /> */}
           <Route exact path="/dashboard">
             <Dashboard />
           </Route>
-          <Route exact path="/scheduler" component={Scheduler} />
+          <Route exact path="/scheduler/:username/:duration" component={Scheduler} />\
+          <Route exact path="/completion" component={Completion} />
           <Route exact path="/profile_settings" component={ProfileSettings} />
           <Route exact path="/confirm" component={Confirm} />
           <Route exact path="/availability" component={Availability} />
           <Route path="*">
-            <Redirect to="/login" />
+            <Redirect to="/dashboard" />
           </Route>
         </Switch>
         {/* </AuthProvider>

--- a/client/src/interface/SchedulerProps.ts
+++ b/client/src/interface/SchedulerProps.ts
@@ -11,9 +11,13 @@ export interface disableDateProp {
   view: string;
 }
 
-export interface urlProp {
+export interface schedUrlProp {
   username: string;
   duration: string;
+}
+
+export interface completionUrlProp {
+  appointID: string;
 }
 
 export interface confirmProp {

--- a/client/src/interface/SchedulerProps.ts
+++ b/client/src/interface/SchedulerProps.ts
@@ -25,7 +25,6 @@ export interface confirmProp {
   duration: number;
   timeZone: string;
   time: Moment;
-  // checkConfirmation: clickEventHandler;
   cancelConfirmation: simpleFunc;
 }
 

--- a/client/src/interface/SchedulerProps.ts
+++ b/client/src/interface/SchedulerProps.ts
@@ -1,0 +1,46 @@
+import { Moment } from 'moment-timezone';
+
+type changeEventHandler = (args: React.ChangeEvent<{ value: unknown }>) => void;
+type clickEventHandler = (args: React.MouseEvent<HTMLButtonElement>) => void;
+type strBoolFunc = (args: string) => boolean;
+type simpleFunc = () => void;
+
+export interface disableDateProp {
+  activeStartDate: Date;
+  date: Date;
+  view: string;
+}
+
+export interface urlProp {
+  username: string;
+  duration: string;
+}
+
+export interface confirmProp {
+  username: string;
+  duration: number;
+  timeZone: string;
+  time: Moment;
+  // checkConfirmation: clickEventHandler;
+  cancelConfirmation: simpleFunc;
+}
+
+export interface TimeZone {
+  [key: string]: { tZone: string; abbr: string };
+}
+
+export interface BTZProps {
+  userTimeZone: string;
+  changeTimeZone: changeEventHandler;
+}
+
+export interface TPProps {
+  startTime: string;
+  endTime: string;
+  userTimeZone: string;
+  timeZone: string;
+  today: Date;
+  duration: number;
+  checkConfirmation: clickEventHandler;
+  checkDisableTime: strBoolFunc;
+}

--- a/client/src/pages/Scheduler/BuildTimeZones.tsx
+++ b/client/src/pages/Scheduler/BuildTimeZones.tsx
@@ -2,17 +2,7 @@ import moment from 'moment-timezone';
 import MenuItem from '@material-ui/core/MenuItem';
 import useStyles from './useStyles';
 import Select from '@material-ui/core/Select';
-
-type eventHandler = (args: React.ChangeEvent<{ value: unknown }>) => void;
-
-interface TimeZone {
-  [key: string]: { tZone: string; abbr: string };
-}
-
-interface BTZProps {
-  userTimeZone: string;
-  changeTimeZone: eventHandler;
-}
+import { BTZProps, TimeZone } from '../../interface/SchedulerProps';
 
 export default function BuildTimeZones(props: BTZProps): JSX.Element {
   const classes = useStyles();

--- a/client/src/pages/Scheduler/Completion/Completion.tsx
+++ b/client/src/pages/Scheduler/Completion/Completion.tsx
@@ -1,0 +1,59 @@
+import { Box } from '@material-ui/core';
+import useStyles from './useStyles';
+import { Typography } from '@material-ui/core';
+import { useHistory, useParams } from 'react-router-dom';
+import { completionUrlProp } from '../../../interface/SchedulerProps';
+import Button from '@material-ui/core/Button';
+
+export default function Completion(): JSX.Element {
+  const history = useHistory();
+  const classes = useStyles();
+
+  // Using the appointID, search an appointment by ID to fill in all the information.
+  const { appointID } = useParams<completionUrlProp>();
+
+  const username = 'John';
+  const duration = 60;
+  const host = 'Kate';
+  const time = '10:00 on February 10, 2020';
+  const timeZone = 'America/Toronto';
+
+  const googleCalen = () => {
+    // Communicate with Google to add this appointment to Google Calendar.
+  };
+
+  const cancelAppointment = () => {
+    // Using appointID, delete this specific appointment from DB.
+  };
+
+  const rescheduleAppointment = () => {
+    cancelAppointment();
+    history.push(`/scheduler/${host}/${duration}`);
+  };
+
+  return (
+    <Box className={classes.wrapper}>
+      <Typography className={classes.header}>
+        Hi {username}, <br />
+        <br />
+        {duration} minute meeting with {host} at {time} ({timeZone}) is scheduled.
+      </Typography>
+      <Box className={classes.buttonWrapper}>
+        <Button className={`${classes.button} ${classes.googleCalen}`}> Add to Google Calendar </Button>
+      </Box>
+      <Typography className={classes.subHeader}> Make changes to this event: </Typography>
+      <Box className={classes.buttonWrapper}>
+        <Box>
+          <Button className={`${classes.button} ${classes.confirm}`} onClick={rescheduleAppointment}>
+            Reschedule
+          </Button>
+        </Box>
+        <Box>
+          <Button className={`${classes.button} ${classes.cancel}`} onClick={cancelAppointment}>
+            Cancel
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/pages/Scheduler/Completion/useStyles.ts
+++ b/client/src/pages/Scheduler/Completion/useStyles.ts
@@ -1,0 +1,54 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  wrapper: {
+    position: 'relative',
+    width: '500px',
+    height: '100%',
+    marginTop: '15vh',
+    margin: 'auto',
+    padding: '100px 50px',
+    backgroundColor: 'white',
+    boxShadow: '0 6px 20px 0 rgba(0, 0, 0, 0.19)',
+  },
+  header: {
+    textAlign: 'left',
+    fontSize: '1em',
+  },
+  subHeader: {
+    textAlign: 'center',
+    fontWeight: 'bold',
+    fontSize: '1em',
+  },
+  buttonWrapper: {
+    textAlign: 'center',
+    margin: '60px 20px',
+  },
+  button: {
+    marginLeft: '5px',
+    marginRight: '5px',
+    fontSize: '0.9em',
+  },
+  googleCalen: {
+    width: '250px',
+    height: '60px',
+    backgroundColor: '#F76900',
+    color: 'white',
+  },
+  confirm: {
+    minWidth: '180px',
+    padding: '15px 0px',
+    marginBottom: '10px',
+    border: '1px solid #F76900',
+    color: '#F76900',
+  },
+  cancel: {
+    minWidth: '180px',
+    padding: '15px 0px',
+    marginBottom: '10px',
+    border: '1px solid gray',
+    color: 'gray',
+  },
+});
+
+export default useStyles;

--- a/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
+++ b/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
@@ -13,8 +13,9 @@ export default function Confirmation(props: confirmProp): JSX.Element {
 
   const completeAppointment = () => {
     // Communicate with the BE to create an appointment with given information.
-    // Redirect the user to the appointment completion page:
-    // /completion/:appointmentID
+    // Redirect the user to the appointment completion page: /completion/:appointmentID
+    // For testing purpose, the current url for completeion page is /completion.
+    history.push('/completion');
   };
 
   return (

--- a/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
+++ b/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
@@ -1,0 +1,34 @@
+import { Box } from '@material-ui/core';
+import useStyles from './useStyles';
+import { Typography } from '@material-ui/core';
+import { useHistory } from 'react-router-dom';
+import { confirmProp } from '../../../interface/SchedulerProps';
+import Button from '@material-ui/core/Button';
+
+export default function Confirmation(props: confirmProp): JSX.Element {
+  const history = useHistory();
+  const classes = useStyles();
+
+  const timeString = props.time.format('HH:mm on MMMM DD, YYYY');
+
+  const completeAppointment = () => {
+    // Redirect to the appointment completion page with enough information.
+  };
+
+  return (
+    <Box className={classes.wrapper}>
+      <Typography className={classes.header}>
+        You are about to make an appointment with {props.username}
+        &nbsp;at {timeString} ({props.timeZone}) for {props.duration} minutes.
+      </Typography>
+      <Box className={classes.buttonWrapper}>
+        <Button className={`${classes.button} ${classes.confirm}`} onClick={completeAppointment}>
+          Continue
+        </Button>
+        <Button className={`${classes.button} ${classes.cancel}`} onClick={props.cancelConfirmation}>
+          Cancel
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
+++ b/client/src/pages/Scheduler/Confirmation/Confirmation.tsx
@@ -12,7 +12,9 @@ export default function Confirmation(props: confirmProp): JSX.Element {
   const timeString = props.time.format('HH:mm on MMMM DD, YYYY');
 
   const completeAppointment = () => {
-    // Redirect to the appointment completion page with enough information.
+    // Communicate with the BE to create an appointment with given information.
+    // Redirect the user to the appointment completion page:
+    // /completion/:appointmentID
   };
 
   return (

--- a/client/src/pages/Scheduler/Confirmation/useStyles.ts
+++ b/client/src/pages/Scheduler/Confirmation/useStyles.ts
@@ -1,0 +1,41 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  wrapper: {
+    position: 'absolute',
+    width: '400px',
+    height: '500px',
+    marginTop: '30vh',
+    margin: 'auto',
+    padding: '100px 50px',
+    border: 'solid 2px #F76900',
+    backgroundColor: 'white',
+    boxShadow: '0 6px 20px 0 rgba(0, 0, 0, 0.19)',
+  },
+  header: {
+    textAlign: 'center',
+    fontWeight: 'bold',
+    fontSize: '1.5em',
+  },
+  buttonWrapper: {
+    textAlign: 'center',
+    margin: '100px 20px',
+  },
+  button: {
+    display: 'inline-block',
+    width: '100px',
+    height: '50px',
+    marginLeft: '5px',
+    marginRight: '5px',
+  },
+  confirm: {
+    backgroundColor: '#F76900',
+    color: 'white',
+  },
+  cancel: {
+    backgroundColor: 'lightgray',
+    color: 'white',
+  },
+});
+
+export default useStyles;

--- a/client/src/pages/Scheduler/Scheduler.tsx
+++ b/client/src/pages/Scheduler/Scheduler.tsx
@@ -111,7 +111,7 @@ export default function Scheduler(): JSX.Element {
           />
         </Box>
       </Box>
-      {confirmTrigger ? (
+      {confirmTrigger && (
         <Confirmation
           username={username}
           duration={Number(duration)}
@@ -119,8 +119,6 @@ export default function Scheduler(): JSX.Element {
           time={moment.tz(dateSelISO, timeZone)}
           cancelConfirmation={cancelConfirmation}
         />
-      ) : (
-        <Box />
       )}
     </Grid>
   );

--- a/client/src/pages/Scheduler/Scheduler.tsx
+++ b/client/src/pages/Scheduler/Scheduler.tsx
@@ -27,9 +27,13 @@ export default function Scheduler(): JSX.Element {
   const endTime = '22:00';
 
   const today = new Date();
+  // Timezone selected on the scheduler.
   const [timeZone, setTimeZone] = useState(userTimeZone);
+  // Date selected on the calendar. Does not take account of timeZone (uses user's PC timezone).
   const [dateSelected, setDateSelected] = useState(today);
+  // Date selected to the ISO string.
   const [dateSelISO, setDateSelISO] = useState(today.toISOString());
+  // Used to open or close the confirmation dialog when time slot is clicked.
   const [confirmTrigger, setConfirmTrigger] = useState(false);
 
   const changeTimeZone = (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -49,6 +53,7 @@ export default function Scheduler(): JSX.Element {
   };
 
   const calenDateToUserTZ = (timeValue: string) => {
+    // Converts "current" time in the selected timezone to the user's base timezone.
     const dateInfo = moment(dateSelected).format('YYYY-MM-DD');
     const momentTZ = moment.tz(`${dateInfo} ${timeValue}`, timeZone);
     const userMoment = moment.tz(momentTZ, userTimeZone);

--- a/client/src/pages/Scheduler/Scheduler.tsx
+++ b/client/src/pages/Scheduler/Scheduler.tsx
@@ -11,7 +11,7 @@ import ScheduleIcon from '@material-ui/icons/Schedule';
 import FormControl from '@material-ui/core/FormControl';
 import BuildTimeZones from './BuildTimeZones';
 import TimePopulator from './TimePopulator';
-import { disableDateProp, urlProp } from '../../interface/SchedulerProps';
+import { disableDateProp, schedUrlProp } from '../../interface/SchedulerProps';
 import Confirmation from './Confirmation/Confirmation';
 
 export default function Scheduler(): JSX.Element {
@@ -20,7 +20,7 @@ export default function Scheduler(): JSX.Element {
 
   // This is the username of the person who is hosting the appointment, not the current user.
   // When integrating, search the user by this username to get specific information.
-  const { username, duration } = useParams<urlProp>();
+  const { username, duration } = useParams<schedUrlProp>();
   const availableDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
   const userTimeZone = 'America/Toronto';
   const startTime = '08:10';

--- a/client/src/pages/Scheduler/TimePopulator.tsx
+++ b/client/src/pages/Scheduler/TimePopulator.tsx
@@ -1,23 +1,9 @@
 import React from 'react';
 import { Box } from '@material-ui/core';
 import useStyles from './useStyles';
-import { ButtonBase } from '@material-ui/core';
 import moment from 'moment-timezone';
 import Button from '@material-ui/core/Button';
-
-type eventHandler = (args: React.MouseEvent<HTMLButtonElement>) => void;
-type strArgFunc = (args: string) => boolean;
-
-interface TPProps {
-  startTime: string;
-  endTime: string;
-  userTimeZone: string;
-  timeZone: string;
-  today: Date;
-  duration: number;
-  getDateInfo: eventHandler;
-  checkDisableTime: strArgFunc;
-}
+import { TPProps } from '../../interface/SchedulerProps';
 
 export default function TimePopulator(props: TPProps): JSX.Element {
   const classes = useStyles();
@@ -31,7 +17,7 @@ export default function TimePopulator(props: TPProps): JSX.Element {
           key={time}
           value={time}
           className={classes.timeSched}
-          onClick={props.getDateInfo}
+          onClick={props.checkConfirmation}
           disabled={props.checkDisableTime(time)}
         >
           {time}


### PR DESCRIPTION
### What this PR does (required):
Modifications to the url of the scheduler.
- When a time slot is clicked, the app prompt a confirmation message. Clicking on the continue button takes the user to the demo completion page, but when integrating, it will create an appointment and send the user to `completion/[appointment id]`.
- When the user continues, the app takes the user to the completion page. All of the information shown in the page are dummy data. When integrating, appointment model with the id from the url will be used to populate all the data.
- Clicking on reschedule will take the user back to the scheduler. When integrating, it will also remove the corresponding appointment model.

### Screenshots / Videos (required):
- New scheduler url of the form `/scheduler/[username]/[duration]`.
![image](https://user-images.githubusercontent.com/43277040/125367778-c78c2b00-e346-11eb-8466-ad4012d3a151.png)

- Confirmation message when the time slot is clicked.
![image](https://user-images.githubusercontent.com/43277040/125367497-3d43c700-e346-11eb-8a68-d21cf44341fb.png)

- Sample of the completion page. 
![image](https://user-images.githubusercontent.com/43277040/125367541-50569700-e346-11eb-9a79-ed0f7e80cc43.png)

### Any information needed to test this feature (required):
- Since there is no legitimate way to get to the scheduler (since dashboard integration is not complete), edit the app.tsx such that `<AuthProvider>` is not being used.
![image](https://user-images.githubusercontent.com/43277040/125367964-3cf7fb80-e347-11eb-9789-1271e39958bd.png)

- `cd /client` -> run `npm install` -> run `npm start`
- `cd /server `-> run `npm install` -> run `npm run dev`
- Go to localhost `http://localhost:3000/scheduler/TEMP/30` (feel free to replace TEMP with some other string and 60 with some other number).

### Any issues with the current functionality (optional):
- N/A
