### PR TITLE
Upon creation, default 60 minutes meeting is created.

### DIFF
--- a/server/utils/passport.js
+++ b/server/utils/passport.js
@@ -10,11 +10,11 @@ passport.use(
       clientID: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL: "/auth/google/callback",
-      proxy: true
+      proxy: true,
     },
     async (accessToken, refreshToken, profile, done) => {
       const existingUser = await User.findOne({
-        email: profile.emails[0].value
+        email: profile.emails[0].value,
       });
 
       if (existingUser) {
@@ -26,13 +26,20 @@ passport.use(
         return done(null, existingUser);
       }
 
-      await new User({
+      const newUser = await new User({
         name: profile.displayName,
         email: profile.emails[0].value,
         google: {
           id: profile.id,
-          refreshToken: refreshToken
-        }
+          refreshToken: refreshToken,
+        },
+      });
+      newUser.save();
+
+      await new Meeting({
+        userId: newUser._id,
+        name: "DEFAULT 60 MIN MEETING",
+        duration: 60,
       }).save();
 
       return done(null, profile);


### PR DESCRIPTION
### What this PR does (required):
- Upon creation, default 60 minutes meeting is created.

### Screenshots / Videos (required):
- An account that was not registered before:
![image](https://user-images.githubusercontent.com/43277040/126078318-e5aa777b-3537-48c6-ad34-5795d48f5fad.png)

- Upon creating an account, a 60 minutes meeting called "DEFAULT 60 MIN MEETING" is created.
![image](https://user-images.githubusercontent.com/43277040/126078370-763097c6-1abe-49e8-bc40-0273fbd0cd0f.png)


### Any information needed to test this feature (required):
- cd `/client` and run `npm install` (also, might need to run `npm update --force` if running into chokidar version issue). Then run `npm start`.
- cd `/server` and run `npm install`. Then run `npm run dev`.
- Create an account and check dashboard.

### Any issues with the current functionality (optional):
- Warnings preventing the heroku app deployment is still there, but this is tackled in #77 
