### PR TITLE
Feature public events be #74

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -21,6 +21,8 @@ const stripeRouter = require("./routes/stripe");
 const googleAvailabilityRouter = require("./routes/availability");
 const googleCreateRouter = require("./routes/googleCreate");
 const googleDeleteRouter = require("./routes/googleDelete");
+const categoryRouter = require("./routes/category");
+const publicEventRouter = require("./routes/publicEvents");
 
 const { json, urlencoded } = express;
 
@@ -62,6 +64,8 @@ app.use("/stripe", stripeRouter);
 app.use("/googleAvailability", googleAvailabilityRouter);
 app.use("/googleCreate", googleCreateRouter);
 app.use("/googleDelete", googleDeleteRouter);
+app.use("/category", categoryRouter);
+app.use("/publicEvent", publicEventRouter);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/client/build")));

--- a/server/controllers/category.js
+++ b/server/controllers/category.js
@@ -1,0 +1,111 @@
+const EventCategory = require("../models/Category");
+const asyncHandler = require("express-async-handler");
+
+// @route POST /category
+// @desc Creates a category.
+// @access Public
+exports.createCategory = asyncHandler(async (req, res, next) => {
+  // Checking for valid input
+  const { categoryName } = req.body;
+  if (typeof categoryName !== "string" || categoryName.trim() === "") {
+    res.status(406);
+    throw new Error("Invalid input, please send non-empty string input.");
+  }
+
+  // Creates a new category.
+  const category = await EventCategory.create(req.body);
+  if (!category) {
+    res.status(406);
+    throw new Error(
+      "Category creation failed. Please check if you have the correct input(s)"
+    );
+  }
+
+  res.status(201).json({ success: { category: category } });
+});
+
+// @route GET /category/all
+// @desc Get all the event categories
+// @access Public
+exports.allCategories = asyncHandler(async (req, res, next) => {
+  const categories = await EventCategory.find();
+
+  res.status(200).json({
+    success: {
+      categories: categories,
+    },
+  });
+});
+
+// @route GET /category?categoryName=
+// @desc Get information with specific name.
+// @access Public
+exports.findCategoryByName = asyncHandler(async (req, res, next) => {
+  const { categoryName } = req.query;
+
+  const category = await EventCategory.findOne({ categoryName: categoryName });
+
+  if (!category) {
+    res.status(404);
+    throw new Error(`No category exists with the given name: ${categoryName}`);
+  }
+
+  res.status(200).json({
+    success: {
+      id: category._id,
+      name: category.categoryName,
+    },
+  });
+});
+
+// @route GET /category/:id
+// @desc Get information with specific name.
+// @access Public
+exports.findCategoryById = asyncHandler(async (req, res, next) => {
+  const id = req.params.id;
+
+  const category = await EventCategory.findById(id);
+
+  if (!category) {
+    res.status(404);
+    throw new Error(`No category exists with the given name: ${categoryName}`);
+  }
+  res.status(200).json({
+    success: {
+      id: category._id,
+      name: category.categoryName,
+    },
+  });
+});
+
+// @route DELETE /category?categoryName=
+// @desc Deletes a category by name.
+// @access Public
+exports.deleteCategoryByName = asyncHandler(async (req, res, next) => {
+  const { categoryName } = req.query;
+  const deleted = await EventCategory.findOneAndDelete({
+    categoryName: categoryName,
+  });
+
+  if (!deleted) {
+    res.status(404);
+    throw new Error("No category with the given name could be deleted.");
+  }
+
+  res.status(200).json({ success: { message: "Category deleted" } });
+});
+
+// @route DELETE /category/:id
+// @desc Deletes a category by id.
+// @access Public
+exports.deleteCategoryById = asyncHandler(async (req, res, next) => {
+  const id = req.params.id;
+  const deleted = await EventCategory.findByIdAndDelete(id);
+
+  if (!deleted) {
+    res.status(404);
+    throw new Error("No category with the given name could be deleted.");
+  }
+
+  res.status(200).json({ success: { message: "Category deleted" } });
+});

--- a/server/controllers/category.js
+++ b/server/controllers/category.js
@@ -38,7 +38,7 @@ exports.allCategories = asyncHandler(async (req, res, next) => {
 });
 
 // @route GET /category?categoryName=
-// @desc Get information with specific name.
+// @desc Get category with specific name.
 // @access Public
 exports.findCategoryByName = asyncHandler(async (req, res, next) => {
   const { categoryName } = req.query;
@@ -59,7 +59,7 @@ exports.findCategoryByName = asyncHandler(async (req, res, next) => {
 });
 
 // @route GET /category/:id
-// @desc Get information with specific name.
+// @desc Get category with specific id.
 // @access Public
 exports.findCategoryById = asyncHandler(async (req, res, next) => {
   const id = req.params.id;

--- a/server/controllers/category.js
+++ b/server/controllers/category.js
@@ -5,14 +5,6 @@ const asyncHandler = require("express-async-handler");
 // @desc Creates a category.
 // @access Public
 exports.createCategory = asyncHandler(async (req, res, next) => {
-  // Checking for valid input
-  const { categoryName } = req.body;
-  if (typeof categoryName !== "string" || categoryName.trim() === "") {
-    res.status(406);
-    throw new Error("Invalid input, please send non-empty string input.");
-  }
-
-  // Creates a new category.
   const category = await EventCategory.create(req.body);
   if (!category) {
     res.status(406);
@@ -70,6 +62,7 @@ exports.findCategoryById = asyncHandler(async (req, res, next) => {
     res.status(404);
     throw new Error(`No category exists with the given name: ${categoryName}`);
   }
+
   res.status(200).json({
     success: {
       id: category._id,

--- a/server/controllers/publicEvent.js
+++ b/server/controllers/publicEvent.js
@@ -1,0 +1,95 @@
+const PublicEvent = require("../models/PublicEvent");
+const asyncHandler = require("express-async-handler");
+
+// @route POST /publicEvent
+// @desc Creates a public event.
+// @access Public
+exports.createPublicEvent = asyncHandler(async (req, res, next) => {
+  // Creates a new category.
+  const publicEvent = await PublicEvent.create(req.body);
+  if (!publicEvent) {
+    res.status(406);
+    throw new Error("Public Event creation failed.");
+  }
+  res.status(201).json({ success: { publicEvent: publicEvent } });
+});
+
+// @route GET /publicEvent?categoryId=...&hostUserName=...
+// @desc Get all Meetings (events) hosted by specific user, under specific category.
+// @access Public
+exports.findPublicEvenByComb = asyncHandler(async (req, res, next) => {
+  const publicEvents = await PublicEvent.find(req.query);
+
+  if (!publicEvents) {
+    res.status(404);
+    throw new Error(`No public events exists with the given combination.`);
+  }
+
+  res.status(200).json({
+    success: {
+      publicEvents: publicEvents,
+    },
+  });
+});
+
+// @route GET /publicEvent/:id
+// @desc Get public event information with specific id.
+// @access Public
+exports.findPublicEvenById = asyncHandler(async (req, res, next) => {
+  const id = req.params.id;
+  const publicEvents = await PublicEvent.findById(id);
+
+  if (!category) {
+    res.status(404);
+    throw new Error(`No category exists with the given name: ${categoryName}`);
+  }
+  res.status(200).json({
+    success: {
+      publicEvents: publicEvents,
+    },
+  });
+});
+
+// @route PATCH /publicEvent?categoryId=...&hostUserName=...
+// @desc Add new public events hosted by specific user, under specific category.
+// @access Public
+exports.addPublicEvent = asyncHandler(async (req, res, next) => {
+  const { meetingId } = req.body;
+  options = { new: true };
+
+  const publicEvents = await PublicEvent.findOne(req.query);
+  publicEvents.meetings.push(meetingId);
+  const updated = await publicEvents.save();
+
+  if (!updated) {
+    res.status(400);
+    throw new Error("Public Event could not be updated with new item.");
+  }
+
+  res.status(200).json({
+    success: {
+      publicEvents: publicEvents,
+    },
+  });
+});
+
+// @route DELETE /publicEvent?categoryId=...&hostUserName=...
+// @desc Deletes a single event with given id.
+// @access Public
+exports.deletePublicEvent = asyncHandler(async (req, res, next) => {
+  const publicEvents = await PublicEvent.findOne(req.query);
+  const { meetingId } = req.body;
+
+  const ind = publicEvents.meetings.indexOf(meetingId);
+  if (ind > -1) {
+    publicEvents.meetings.splice(ind, 1);
+  }
+  const deleted = await publicEvents.save();
+
+  if (!deleted) {
+    res.status(404);
+    throw new Error("No category with the given name could be deleted.");
+  }
+
+  res.status(200).json({ success: { message: "Category deleted" } });
+});

--- a/server/controllers/publicEvent.js
+++ b/server/controllers/publicEvent.js
@@ -17,7 +17,7 @@ exports.createPublicEvent = asyncHandler(async (req, res, next) => {
 // @route GET /publicEvent?categoryId=...&hostUserName=...
 // @desc Get all Meetings (events) hosted by specific user, under specific category.
 // @access Public
-exports.findPublicEvenByComb = asyncHandler(async (req, res, next) => {
+exports.findPublicEventByComb = asyncHandler(async (req, res, next) => {
   const publicEvents = await PublicEvent.find(req.query);
 
   if (!publicEvents) {
@@ -35,13 +35,13 @@ exports.findPublicEvenByComb = asyncHandler(async (req, res, next) => {
 // @route GET /publicEvent/:id
 // @desc Get public event information with specific id.
 // @access Public
-exports.findPublicEvenById = asyncHandler(async (req, res, next) => {
+exports.findPublicEventById = asyncHandler(async (req, res, next) => {
   const id = req.params.id;
   const publicEvents = await PublicEvent.findById(id);
 
-  if (!category) {
+  if (!publicEvents) {
     res.status(404);
-    throw new Error(`No category exists with the given name: ${categoryName}`);
+    throw new Error(`No public event exists with given id.`);
   }
   res.status(200).json({
     success: {

--- a/server/middleware/validateCategory.js
+++ b/server/middleware/validateCategory.js
@@ -1,0 +1,11 @@
+exports.validateInput = (req, res, next) => {
+  const { categoryName } = req.body;
+
+  if (typeof categoryName !== "string" || categoryName.trim() === "") {
+    res.status(406);
+    throw new Error("Invalid input, please send non-empty string input.");
+  }
+
+  // We are good to move on.
+  next();
+};

--- a/server/middleware/validatePublicEvent.js
+++ b/server/middleware/validatePublicEvent.js
@@ -1,0 +1,53 @@
+const Meeting = require("./Meeting");
+
+exports.validatePublicEvent = (req, res, next) => {
+  const { categoryId, hostUserName, hostEmail, events } = req.body;
+
+  // Checking for valid input
+  if (!categoryId || !hostUserName.trim() || !hostEmail.trim()) {
+    res.sendStatus(406);
+  }
+  if (events) {
+    for (let event in events) {
+      if (!(event instanceof Meeting)) {
+        res.sendStatus(406);
+      }
+    }
+  }
+  // Prevent another creation of the same category-user combination.
+  const query = { categoryId: categoryId, hostUserName: hostUserName };
+  const preExisting = await PublicEvent.findOne(query);
+  if (preExisting) {
+    res.sendStatus(400);
+  }
+  // We are good to move on.
+  next();
+};
+
+exports.validateCombination = (req, res, next) => {
+  const { categoryId, hostUserName } = req.query;
+
+  if (!categoryId || !hostUserName) {
+    res.sendStatus(404);
+  }
+
+  // We are good to move on.
+  next();
+};
+
+exports.validateCombPatch = (req, res, next) => {
+  const { categoryId, hostUserName } = req.query;
+  const { meetingId } = req.body;
+
+  if (!categoryId || !hostUserName || meetingId) {
+    res.sendStatus(404);
+  }
+
+  const publicEvents = await PublicEvent.findOne(req.query);
+  if (!publicEvents || !publicEvents.meetings.includes(meetingId)) {
+    res.sendStatus(404);
+  }
+
+  // We are good to move on.
+  next();
+};

--- a/server/models/Category.js
+++ b/server/models/Category.js
@@ -1,0 +1,11 @@
+const mongoose = require("mongoose");
+
+const categorySchema = new mongoose.Schema({
+  categoryName: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+});
+
+module.exports = EventCategory = mongoose.model("category", categorySchema);

--- a/server/models/PublicEvent.js
+++ b/server/models/PublicEvent.js
@@ -1,0 +1,23 @@
+const mongoose = require("mongoose");
+
+const publicEventSchema = new mongoose.Schema({
+  categoryId: {
+    type: mongoose.Types.ObjectId,
+    ref: "category",
+    required: true,
+  },
+  hostUserName: {
+    type: String,
+    required: true,
+  },
+  hostEmail: {
+    type: String,
+    required: true,
+  },
+  events: {
+    type: [String],
+    default: [],
+  },
+});
+
+module.exports = PublicEvent = mongoose.model("publicEvent", publicEventSchema);

--- a/server/models/PublicEvent.js
+++ b/server/models/PublicEvent.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const Meeting = require("./Meeting");
 
 const publicEventSchema = new mongoose.Schema({
   categoryId: {
@@ -10,12 +11,8 @@ const publicEventSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  hostEmail: {
-    type: String,
-    required: true,
-  },
-  events: {
-    type: [String],
+  meetings: {
+    type: [mongoose.Types.ObjectId],
     default: [],
   },
 });

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -1,0 +1,20 @@
+const express = require("express");
+const router = express.Router();
+
+const {
+  createCategory,
+  allCategories,
+  findCategoryByName,
+  findCategoryById,
+  deleteCategoryByName,
+  deleteCategoryById,
+} = require("../controllers/category");
+
+router.route("/").post(createCategory);
+router.route("/all").get(allCategories);
+router.route("/").get(findCategoryByName);
+router.route("/:id").get(findCategoryById);
+router.route("/").delete(deleteCategoryByName);
+router.route("/:id").delete(deleteCategoryById);
+
+module.exports = router;

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -9,8 +9,9 @@ const {
   deleteCategoryByName,
   deleteCategoryById,
 } = require("../controllers/category");
+const { validateInput } = require("../middleware/validateCategory");
 
-router.route("/").post(createCategory);
+router.route("/").post(validateInput, createCategory);
 router.route("/all").get(allCategories);
 router.route("/").get(findCategoryByName);
 router.route("/:id").get(findCategoryById);

--- a/server/routes/publicEvents.js
+++ b/server/routes/publicEvents.js
@@ -1,0 +1,23 @@
+const express = require("express");
+const router = express.Router();
+
+const {
+  createPublicEvent,
+  findPublicEvenByComb,
+  findPublicEvenById,
+  addPublicEvent,
+  deletePublicEvent,
+} = require("../controllers/publicEvent");
+const {
+  validatePublicEvent,
+  validateCombination,
+  validateCombPatch,
+} = require("../middleware/validatePublicEvent");
+
+router.route("/").post(validatePublicEvent, createPublicEvent);
+router.route("/").get(validateCombination, findPublicEvenByComb);
+router.route("/:id").get(findPublicEvenById);
+router.route("/").patch(validateCombPatch, addPublicEvent);
+router.route("/").delete(validateCombPatch, deletePublicEvent);
+
+module.exports = router;

--- a/server/routes/publicEvents.js
+++ b/server/routes/publicEvents.js
@@ -3,8 +3,8 @@ const router = express.Router();
 
 const {
   createPublicEvent,
-  findPublicEvenByComb,
-  findPublicEvenById,
+  findPublicEventByComb,
+  findPublicEventById,
   addPublicEvent,
   deletePublicEvent,
 } = require("../controllers/publicEvent");
@@ -12,12 +12,13 @@ const {
   validatePublicEvent,
   validateCombination,
   validateCombPatch,
+  validateCombDel,
 } = require("../middleware/validatePublicEvent");
 
 router.route("/").post(validatePublicEvent, createPublicEvent);
-router.route("/").get(validateCombination, findPublicEvenByComb);
-router.route("/:id").get(findPublicEvenById);
+router.route("/").get(validateCombination, findPublicEventByComb);
+router.route("/:id").get(findPublicEventById);
 router.route("/").patch(validateCombPatch, addPublicEvent);
-router.route("/").delete(validateCombPatch, deletePublicEvent);
+router.route("/").delete(validateCombDel, deletePublicEvent);
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Created BE model, routes, and controllers to support public events with categorization.
- Idea: The public events are categorized using two factors: category and the host user. Each public event documents will have meetings array which contains the meeting ids for the public events from specific host user, under specific category. Such design choice was made to allow the users to search the public events by id, and then further by the host. As more users start to use this app, there are going to be a huge number of public events. Such functionality will help the users to navigate to the public events they want.

### Screenshots / Videos (required):

**NOTE THAT FOR GET REQUESTS, BODY IS NOT BEING USED**

- Manipulating categories:

Create new category:
![image](https://user-images.githubusercontent.com/43277040/126813197-d5ac616e-00c1-4f51-9f0d-7c8d6a27d088.png)

Get all categories:
![image](https://user-images.githubusercontent.com/43277040/126813245-e024f31a-4ce1-4f5a-ae45-0b9dede4db1f.png)

Get category by category name:
![image](https://user-images.githubusercontent.com/43277040/126813349-97b9bdbf-0123-4957-8a6d-2d70c8013bf9.png)

Get category by id:
![image](https://user-images.githubusercontent.com/43277040/126813409-362a2348-a2eb-496b-8e2f-abe1031c52c4.png)

Delete category by category name:
![image](https://user-images.githubusercontent.com/43277040/126813453-1dda3794-6ad0-4522-829b-67af33343e35.png)
![image](https://user-images.githubusercontent.com/43277040/126813497-bc0ee936-4115-465e-9843-87f0391e5b32.png)

- Manupulating public events:

Create new public event for specific category - user combination:
![image](https://user-images.githubusercontent.com/43277040/126815380-8c2d4e6e-fe69-4d8d-ab35-370356ced58b.png)

Trying to create public event with the same specific category - user combination:
![image](https://user-images.githubusercontent.com/43277040/126815485-ad5648e5-fe12-4044-9063-7f02bdaef7c9.png)

As long as one of the combination is specified, it will return an array of public events:
![image](https://user-images.githubusercontent.com/43277040/126818158-ed7a4eda-a92b-4e4b-87ea-12e03e9dd5cc.png)
![image](https://user-images.githubusercontent.com/43277040/126818201-fd61276d-b670-4a23-b70b-d5da5d98b5e8.png)

Getting public event information for specific category - user combination:
![image](https://user-images.githubusercontent.com/43277040/126816067-87e30398-d1ef-4a58-b5c9-afbdf282afc3.png)

Getting public event information of specific category - user combination by id:
![image](https://user-images.githubusercontent.com/43277040/126816490-0b23a2ce-5537-414f-8c2d-628dd2b9a270.png)

Adding new event to public event of specific category - user combination:
![image](https://user-images.githubusercontent.com/43277040/126817228-aacb73d7-8761-4d27-bbe0-1a358110b0f7.png)

Deleting specific event from public event of specific category - user combination:
![image](https://user-images.githubusercontent.com/43277040/126817419-2a26cee4-08f4-406a-8d89-2ea1c04aa739.png)
![image](https://user-images.githubusercontent.com/43277040/126817501-9cc356ad-2eab-45f5-9d83-08788cb422d5.png)


### Any information needed to test this feature (required):
- cd `/server` and run `npm install`. Then run `npm run dev`.
- Use Postman to send requests.

### Any issues with the current functionality (optional):
- N/A
